### PR TITLE
Changed timestamp to reflect real odometry time

### DIFF
--- a/nodes/basic_odom_publisher
+++ b/nodes/basic_odom_publisher
@@ -97,7 +97,7 @@ class DeadReckoning(object):
         self.odom.twist.twist.linear.x = ddr
         self.odom.twist.twist.angular.z = dda
         
-        self.odom.header.stamp = rospy.Time.now()
+        self.odom.header.stamp = data.header.stamp
 
         # If our wheels aren't moving, we're likely not moving at all.
         # Adjust covariance appropriately


### PR DESCRIPTION
It makes no sense to use time.now() since the previous time is closer to the real time the odometry was taken.
It also allows us to easily run this node with rosbag play.
