### PR TITLE
Added support for publishing raw wheel encoder ticks

### DIFF
--- a/include/husky_base/husky_hardware.h
+++ b/include/husky_base/husky_hardware.h
@@ -40,6 +40,8 @@
 #include "ros/ros.h"
 #include "sensor_msgs/JointState.h"
 #include "husky_msgs/HuskyStatus.h"
+#include "husky_msgs/HuskyWheelTick.h"
+
 #include <string>
 
 namespace husky_base
@@ -54,6 +56,7 @@ namespace husky_base
     HuskyHardware(ros::NodeHandle nh, ros::NodeHandle private_nh);
 
     void updateJointsFromHardware();
+    void updateWheelTicksFromHardware();
 
     void writeCommandsToHardware();
 
@@ -86,10 +89,16 @@ namespace husky_base
     ros::Publisher diagnostic_publisher_;
     husky_msgs::HuskyStatus husky_status_msg_;
     diagnostic_updater::Updater diagnostic_updater_;
+
     HuskyHardwareDiagnosticTask<clearpath::DataSystemStatus> system_status_task_;
     HuskyHardwareDiagnosticTask<clearpath::DataPowerSystem> power_status_task_;
     HuskyHardwareDiagnosticTask<clearpath::DataSafetySystemStatus> safety_status_task_;
     HuskySoftwareDiagnosticTask software_status_task_;
+
+    //Wheel tick support
+    ros::Publisher wheel_publisher_;
+    husky_msgs::HuskyWheelTick husky_wheel_msg_;
+    void initializeWheelTicks();
 
     // ROS Parameters
     double wheel_diameter_, max_accel_, max_speed_;

--- a/src/husky_base.cpp
+++ b/src/husky_base.cpp
@@ -41,6 +41,8 @@ void controlLoop(const ros::TimerEvent &event, husky_base::HuskyHardware &husky,
 {
   husky.reportLoopFrequency(event);
   husky.updateJointsFromHardware();
+  husky.updateWheelTicksFromHardware();
+
   cm.update(event.current_real, event.current_real - event.last_real);
   husky.writeCommandsToHardware();
 }


### PR DESCRIPTION
For an ongoing research project, I needed raw encoder ticks - this patch exposes the Horizon DataEncodersRaw message as a ROS topic /wheel_tick. Companion pull req in husky_msgs for the HuskyWheelTick message.
